### PR TITLE
lang.python: option to wrap globals in pseudo class `--globals-as-class`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ or
 python -m syrenka classdiagram <project_dir> --detect-project-dir
 ```
 
-there is also optio to filter files, see `python -m syrenka classdiagram -h` for more details
+- there is also option to filter files, see `python -m syrenka classdiagram -h` for more details
+- there is now an option to put global functions/assignments in pseudo-class _globals_ per module with flag `--globals-as-class`
 
 
 ## Example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syrenka"
-version = "0.4.7"
+version = "0.4.8"
 authors = [
     {name = "Bartlomiej Cieszkowski", email = "bartlomiej.cieszkowski@gmail.com"},
 ]

--- a/src/syrenka/__main__.py
+++ b/src/syrenka/__main__.py
@@ -28,6 +28,7 @@ def _class_diagram(args):
         detect_project_dir=args.detect_project_dir,
         exclude=args.exclude,
         only=args.only,
+        globals_as_class=args.module_globals_as_class,
     )
 
     class_diagram = syrenka.SyrenkaClassDiagram()
@@ -57,6 +58,11 @@ def _main():
         "--only",
         nargs="+",
         help="list of files/paths to only parse, checks if relative path startswith any of args",
+    )
+    class_diagram.add_argument(
+        "--module-globals-as-class",
+        action="store_true",
+        help="often there are methods/globals without encapsulating class in a module, pass this flag to wrap them in pseudo-class",
     )
     class_diagram.add_argument("--detect-project-dir", action="store_true")
     # class_diagram.add_argument("--filter", nargs="+", default=None)

--- a/src/syrenka/__main__.py
+++ b/src/syrenka/__main__.py
@@ -60,7 +60,7 @@ def _main():
         help="list of files/paths to only parse, checks if relative path startswith any of args",
     )
     class_diagram.add_argument(
-        "--module-globals-as-class",
+        "--globals-as-class",
         action="store_true",
         help="often there are methods/globals without encapsulating class in a module, pass this flag to wrap them in pseudo-class",
     )

--- a/src/syrenka/lang/python.py
+++ b/src/syrenka/lang/python.py
@@ -35,6 +35,7 @@ SKIP_BASES_LIST = ["object", "ABC"]
 class PythonAstModuleParams:
     ast_module: ast.Module
     filepath: Path
+    globals_as_class: bool = False
 
 
 @dataclass(frozen=True)
@@ -442,6 +443,7 @@ class PythonModuleAnalysis(LangAnalysis):
         detect_project_dir: bool = True,
         exclude: Iterable[str] | None = None,
         only: Iterable[str] | None = None,
+        globals_as_class: bool = False,
     ) -> Iterable[PythonAstClassParams]:
         root = path
 
@@ -474,7 +476,9 @@ class PythonModuleAnalysis(LangAnalysis):
                 if append:
                     ast_modules.append(
                         PythonAstModuleParams(
-                            ast_module=PythonModuleAnalysis.get_ast(p), filepath=p
+                            ast_module=PythonModuleAnalysis.get_ast(p),
+                            filepath=p,
+                            globals_as_class=globals_as_class,
                         )
                     )
             else:
@@ -502,7 +506,8 @@ class PythonModuleAnalysis(LangAnalysis):
                             module_name=module_name,
                         )
                     )
-                else:
+                elif params.globals_as_class:
+                    # TODO
                     # print(ast_node)
                     pass
         return class_params

--- a/uv.lock
+++ b/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "syrenka"
-version = "0.4.7"
+version = "0.4.8"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
often there are items - functions, globals - in module without encapsulating class  
in unstructured code this leads to empty class diagram  
by showing them as pseudo-class diagram would make more sense