### PR TITLE
lang.python: globals flag fix, add pseudoclass only if found FunctionDef

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syrenka"
-version = "0.4.8"
+version = "0.4.9"
 authors = [
     {name = "Bartlomiej Cieszkowski", email = "bartlomiej.cieszkowski@gmail.com"},
 ]

--- a/src/syrenka/__main__.py
+++ b/src/syrenka/__main__.py
@@ -28,7 +28,7 @@ def _class_diagram(args):
         detect_project_dir=args.detect_project_dir,
         exclude=args.exclude,
         only=args.only,
-        globals_as_class=args.module_globals_as_class,
+        globals_as_class=args.globals_as_class,
     )
 
     class_diagram = syrenka.SyrenkaClassDiagram()

--- a/src/syrenka/lang/python.py
+++ b/src/syrenka/lang/python.py
@@ -516,9 +516,10 @@ class PythonModuleAnalysis(LangAnalysis):
                         )
                     )
                 elif params.globals_as_class and not found_non_class:
-                    if type(ast_node) not in [ast.Import, ast.ImportFrom]:
+                    if isinstance(ast_node, ast.FunctionDef):
+                        # not in [ast.Import, ast.ImportFrom]:
                         found_non_class = True
-                    # TODO
+                    # open: only function defs, do we want assigns
                     pass
             if params.globals_as_class and found_non_class:
                 logger.debug(

--- a/uv.lock
+++ b/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "syrenka"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
flag from arg wasn't updated, so it was impossible to use from cli only add pseudo class if it has function defs - empty globals were added