### PR TITLE
lang.python: fix opening python files - open them in binary mode

### DIFF
--- a/src/syrenka/lang/python.py
+++ b/src/syrenka/lang/python.py
@@ -573,7 +573,11 @@ class PythonModuleAnalysis(LangAnalysis):
 
         ast_module = PythonModuleAnalysis.ast_cache.get(filename, None)
         if ast_module is None:
-            with filename.open("r", encoding="utf-8") as f:
+            # open file as binary and pass it to ast, it can handle different encodings
+            # if we open it as regular "r" we will possibly get decode errors in case of some files
+            # as it will be open with SOME encoding
+            with filename.open("rb") as f:
+                print(filename)
                 ast_module = ast.parse(f.read(), str(filename.name))
             PythonModuleAnalysis.ast_cache[filename] = ast_module
 


### PR DESCRIPTION
we were hardcoding "r" with utf-8 encoding, which would lead to possible UnicodeDecodeErrors, for example with cpython:
`python -m syrenka classdiagram cpython/Lib/test/encoded_modules/module_iso_8859_1.py`