### PR TITLE
lang.python: indicate that there is syntax error explictly

### DIFF
--- a/src/syrenka/lang/python.py
+++ b/src/syrenka/lang/python.py
@@ -578,7 +578,11 @@ class PythonModuleAnalysis(LangAnalysis):
             # as it will be open with SOME encoding
             with filename.open("rb") as f:
                 print(filename)
-                ast_module = ast.parse(f.read(), str(filename.name))
+                try:
+                    ast_module = ast.parse(f.read(), str(filename.name))
+                except SyntaxError as ex:
+                    print(f"FAIL: File doesn't parse correctly: {ex}", file=sys.stderr)
+                    raise ex
             PythonModuleAnalysis.ast_cache[filename] = ast_module
 
         return ast_module


### PR DESCRIPTION
print info, and raise it again
found while parsing newer python files with
PEP 758 – Allow except and except* expressions without parentheses implemented, and parsing it with older python version :)